### PR TITLE
Fixed issues compiling with Xcode 14 in MacOSX Ventura and  Intel processor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Util/Build
 Install
 Plugins
 !Unreal/CarlaUE4/Plugins
+cmake-build-debug
 
 /ExportedMaps
 /Import/*
@@ -47,3 +48,5 @@ _out*
 _site
 core
 profiler.csv
+CarlaUE4.xcworkspace
+OptionalModules.ini

--- a/Docs/build_mac.md
+++ b/Docs/build_mac.md
@@ -25,8 +25,22 @@ brew update && brew upgrade
 
 brew install --build-from-source mono
 
-brew install coreutils ninja wget autoconf automake curl libtool libpng aria2 libiconv
+brew install coreutils ninja wget autoconf automake curl libtool aria2 libiconv
+
+# Media libraries
+brew install libpng webp libtiff little-cms2 jpeg-turbo
 ```
+
+IMPORTANT FOR M1 ONLY:
+
+Set some necessary flags to link the installed libraries from a brew with the clang compiler in the M1 architecture. This step is not required for Intel.
+
+```
+export CPATH=/opt/homebrew/include
+export LIBRARY_PATH=/opt/homebrew/lib
+```
+
+And save them to your `~/.zshrc` or `~/.bashrc` configuration files.
 
 I recommend installing python through conda on mac:
 ```bash
@@ -58,6 +72,9 @@ cd /PATH/TO/UnrealEngine
 
 # then finally build UE4
 xcodebuild -scheme UE4 -target UE4 -UseModernBuildSystem=YES # this takes a while to complete
+
+# for Xcode 14 do:
+xcodebuild -scheme UE4 -target UE4 -UseModernBuildSystem=YES GENERATE_INFOPLIST_FILE=YES
 
 # make sure to add the right UnrealEngine path as UE4_ROOT:
 export UE4_ROOT=/PATH/TO/UnrealEngine # or add it in your .zshrc
@@ -139,3 +156,19 @@ export PYTHONPATH="${PYTHONPATH}:/PATH/TO/CARLA/PythonAPI/carla/dist/carla-0.9.1
 # I simply put this in my .zshrc file
 ```
 Then you should be able to quickly `import carla` without hassle!
+
+After running `make package`, a building project is created. You can find this build in the path:
+
+```
+/path/to/carla/Dist/CARLA_Shipping_0.9.13-...-dirty/MacNoEditor/
+```
+
+This folder can be moved to another place if you prefer.
+
+The build folder includes the compiled server app for Mac `CarlaUE4-Mac-Shipping.app`.
+
+To run the server in headless mode, to be used by a client, you can run the following command in the terminal. This mode loads faster, and it delays around 20 seconds to be ready for the client:
+
+```
+open CarlaUE4-Mac-Shipping.app --args -RenderOffScreen
+```

--- a/PythonAPI/carla/setup.py
+++ b/PythonAPI/carla/setup.py
@@ -94,10 +94,7 @@ def get_libcarla_extensions():
                 extra_link_args += ['-ljpeg', '-ltiff']
                 extra_compile_args += ['-DLIBCARLA_IMAGE_WITH_PNG_SUPPORT=false']
             else:
-                if is_mac:
-                    extra_link_args += ['-lpng'] # TODO: find a suitable MacOS replacement for libjpeg and libtiff
-                else:
-                    extra_link_args += ['-lpng', '-ljpeg', '-ltiff']
+                extra_link_args += ['-lpng', '-ljpeg', '-ltiff']
                 extra_compile_args += ['-DLIBCARLA_IMAGE_WITH_PNG_SUPPORT=true']
             # @todo Why would we need this?
             # include_dirs += ['/usr/lib/gcc/x86_64-linux-gnu/7/include']

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -161,7 +161,7 @@ if ${BUILD_CARLAUE4} ; then
 
   log "Build CarlaUE4 project."
   if ${MAC_OS}; then
-    xcodebuild -scheme CarlaUE4 -target CarlaUE4Editor -UseModernBuildSystem=YES
+    xcodebuild -scheme CarlaUE4 -target CarlaUE4Editor -UseModernBuildSystem=YES GENERATE_INFOPLIST_FILE=YES
   else
     make CarlaUE4Editor
   fi

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -442,7 +442,7 @@ XERCESC_VERSION=3.2.3
 XERCESC_BASENAME=xerces-c-${XERCESC_VERSION}
 
 XERCESC_TEMP_FOLDER=${XERCESC_BASENAME}
-XERCESC_REPO=https://ftp.cixug.es/apache//xerces/c/3/sources/xerces-c-${XERCESC_VERSION}.tar.gz
+XERCESC_REPO=https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCESC_VERSION}.tar.gz
 
 XERCESC_SRC_DIR=${XERCESC_BASENAME}-source
 XERCESC_INSTALL_DIR=${XERCESC_BASENAME}-install


### PR DESCRIPTION
Changes should be compatible with apple M1.

- Tested in a Macbook pro 2019 with Intel and AMD Radeon dedicated graphic card.

- fixed broken URL for the `XERCESC_REPO` variable in Util/BuildTools/Setup.sh script.

- Added comments to the Mac compilation document.
